### PR TITLE
Enable pre-commit.ci to run checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,82 @@
+repos:
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: check-added-large-files
+  - id: check-merge-conflict
+  - id: detect-private-key
+  - id: end-of-file-fixer
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace
+
+- repo: https://github.com/PyCQA/autoflake
+  rev: v1.7.7
+  hooks:
+  - id: autoflake
+    args:
+    - "--in-place"
+    - "--ignore-init-module-imports"
+    - "--remove-all-unused-imports"
+    - "--remove-unused-variables"
+
+- repo: https://github.com/MarcoGorelli/auto-walrus
+  rev: v0.2.1
+  hooks:
+  - id: auto-walrus
+
+- repo: https://github.com/kplaube/pre-commit-dodgy
+  rev: "0.0.2"
+  hooks:
+  - id: dodgy
+
+- repo: https://github.com/PyCQA/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+    args:
+    - "--profile=black"
+    - "--force-single-line-imports"
+
+- repo: https://github.com/PyCQA/docformatter
+  rev: v1.5.0
+  hooks:
+  - id: docformatter
+    args:
+    - "--in-place"
+    - "--wrap-summaries=88"
+    - "--wrap-descriptions=88"
+    - "--pre-summary-newline"
+
+- repo: https://github.com/psf/black
+  rev: 22.10.0
+  hooks:
+  - id: black
+
+- repo: https://github.com/PyCQA/flake8
+  rev: '5.0.4'
+  hooks:
+  - id: flake8
+    args:
+    - "--max-line-length=88"
+    - "--extend-ignore=E203"
+    additional_dependencies:
+    - flake8-bugbear==22.10.27
+    - flake8-docstrings==1.6.0
+    - flake8-eradicate==1.4.0
+    - pep8-naming==0.13.2
+
+- repo: https://github.com/ikamensh/flynt
+  rev: '0.76'
+  hooks:
+  - id: flynt
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.2.2
+  hooks:
+  - id: pyupgrade
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.991
+  hooks:
+  - id: mypy

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,6 @@ lint:
 lint-fix:
 	pre-commit run --all-files
 
-.PHONY: mypy
-mypy:
-	mypy --package $(APP_NAME) --namespace-packages
-
 .PHONY: test
 test:
 	pytest -x -n=auto --dist=loadfile


### PR DESCRIPTION
* Add pre-commit config file, enabling pre-commit.ci service to run static analysis tools on PRs and to share config with contributors