### PR TITLE
Enable continuous deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,8 +2,7 @@ name: Consent API Deployment
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches: ['main']
 
 env:
   REGISTRY: gcr.io
@@ -19,11 +18,20 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: read|write
       id-token: write
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Bump version and push tag
+      id: release
+      uses: rymndhng/release-on-push-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        bump_version_scheme: minor
+        use_github_release_notes: true
 
     - name: Authenticate to Google Cloud
       id: auth
@@ -47,7 +55,7 @@ jobs:
         push: true
         tags: |
           ${{ env.IMAGE_NAME }}:latest
-          ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          ${{ env.IMAGE_NAME }}:${{ steps.release.outputs.tag_name }}
 
     - name: Deploy to Cloud Run
       id: deploy
@@ -55,7 +63,7 @@ jobs:
       with:
         service: ${{ env.SERVICE_ID }}
         region: ${{ env.REGION }}
-        image: ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+        image: ${{ env.IMAGE_NAME }}:${{ steps.release.output.tag_name }}
 
     - name: Show URL
       run: |

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -1,40 +1,31 @@
 name: Consent API CI
 
 on:
-  push:
-    branches: [ $default-branch ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: ['main']
 
 env:
+  FLASK_APP: consent_api
   ENV: ci
 
 jobs:
 
-  lint:
-    name: Run linters
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version-file: '.python-version'
-        cache: pip
-
-    - name: Install dependencies
-      run: |
-        make deps
-
-    - name: Lint
-      run: |
-        make lint
-
   test:
     name: Run tests
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 2s
+          --health-retries 10
+        ports:
+          - 5432:5432
 
     steps:
     - uses: actions/checkout@v3
@@ -50,8 +41,8 @@ jobs:
         make deps
 
     - name: Run tests
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
       run: |
+        make run-migrations
         make test-coverage
-
-    - name: Report code coverage
-      uses: codecov/codecov-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,6 @@ repos:
     additional_dependencies:
     - flake8-bugbear==22.10.27
     - flake8-docstrings==1.6.0
-    - flake8-eradicate==1.4.0
     - pep8-naming==0.13.2
     exclude: migrations
 
@@ -81,3 +80,8 @@ repos:
   rev: v0.991
   hooks:
   - id: mypy
+    args:
+    - "--ignore-missing-imports"
+    - "--scripts-are-modules"
+    - "--exclude"
+    - "migrations"

--- a/Makefile
+++ b/Makefile
@@ -20,24 +20,27 @@ deps:
 lint:
 	black --check .
 	isort --check-only --profile=black --force-single-line-imports .
-	flake8 --max-line-length=88 --extend-ignore=E203
-	mypy --namespace-packages .
+	flake8 --max-line-length=88 --extend-ignore=E203 --exclude migrations
 
 .PHONY: lint-fix
 lint-fix:
 	pre-commit run --all-files
 
+.PHONY: run-migrations
+run-migrations:
+	flask db upgrade
+
 .PHONY: test
 test:
-	pytest -x -n=auto --dist=loadfile
+	pytest -x -n=auto --dist=loadfile -W ignore::DeprecationWarning
 
 .PHONY: test-coverage
 test-coverage:
-	pytest -n=auto --cov --cov-report=xml --cov-report=term
+	pytest -n=auto --cov --cov-report=xml --cov-report=term -W ignore::DeprecationWarning
 
 .PHONY: run
 run:
-	flask --app $(APP_NAME):app --debug run --debugger --reload
+	flask --debug run --debugger --reload
 
 .PHONY: docker-image
 docker-image: clean

--- a/consent_api/config.py
+++ b/consent_api/config.py
@@ -1,6 +1,5 @@
 """Flask app configuration."""
 import os
-from urllib.parse import quote
 
 from dotenv import load_dotenv
 
@@ -11,24 +10,4 @@ DEBUG = env.get("DEBUG", True)
 
 SECRET_KEY = env.get("SECRET_KEY", os.urandom(24))
 
-
-def build_db_url(
-    type: str = "",
-    name: str = "",
-    username: str = "",
-    password: str = "",
-    host: str = "",
-    port: str | int = "",
-    sock: str | None = None,
-    **kwargs,
-) -> str:
-    """Construct a database url from parts."""
-    creds = ":".join([quote(s) for s in (username, password) if s])
-    addr = (f"{creds}@" if creds else "") + host + (f":{port}" if port else "")
-    sock = f"?unix_sock={sock}" if sock else ""
-    return f"{type}://{addr}/{name}{sock}"
-
-
-SQLALCHEMY_DATABASE_URI = build_db_url(
-    **{k[3:].lower(): v for k, v in env.items() if k.startswith("DB_")},
-)
+SQLALCHEMY_DATABASE_URI = env["DATABASE_URL"]

--- a/consent_api/models.py
+++ b/consent_api/models.py
@@ -7,9 +7,8 @@ from dataclasses import fields
 from typing import ClassVar
 
 from sqlalchemy.dialects.postgresql import JSON
-from sqlalchemy.ext.declarative import DeclarativeMeta
+from sqlalchemy.orm import DeclarativeMeta
 
-import consent_api
 from consent_api import db
 from consent_api.util import generate_uid
 
@@ -47,8 +46,7 @@ class CookieConsent:
 CookieConsent.ACCEPT_ALL = CookieConsent(*([True] * len(fields(CookieConsent))))
 CookieConsent.REJECT_ALL = CookieConsent()
 
-
-BaseModel: DeclarativeMeta = consent_api.db.Model
+BaseModel: DeclarativeMeta = db.Model
 
 
 class UserConsent(BaseModel):

--- a/consent_api/tests/conftest.py
+++ b/consent_api/tests/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for all tests."""
+
 import pytest
 import sqlalchemy
-from flask_migrate import upgrade
 
 TEST_DATABASE_URI = "sqlite:///:memory:"
 
@@ -26,12 +26,6 @@ def app():
 def db(app):
     """Create a test database and drop it when tests are done."""
     from consent_api import db as _db
-
-    sqlalchemy.orm.configure_mappers()
-
-    _db.drop_all()
-
-    upgrade()
 
     yield _db
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -3,7 +3,6 @@ black==22.10.0
 flake8==5.0.4
 flake8-bugbear==22.10.27
 flake8-docstrings==1.6.0
-flake8-eradicate==1.4.0
 
 isort==5.10.1
 mypy==0.991


### PR DESCRIPTION
* Fix bug that meant CI workflow was not triggered
* Fix test job to setup a test database and run migrations before tests
* Remove lint job - pre-commit.ci does this
* Ignore deprecation warnings to keep test output more readable
* Refactor database connection config to use DATABASE_URL env var - easier for
  configuring Google Cloud secrets
* Remove flake8-eradicate - doesn't work with latest flake8 (v6)
* Add a step to deploy workflow to auto-increment the tag version number and create a
  Github release on pushes to the main branch