### PR TITLE
Fix consent updates

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      packages: write
 
     steps:
     - uses: actions/checkout@v3
@@ -69,26 +68,3 @@ jobs:
         service: ${{ env.SERVICE_ID }}
         region: ${{ env.REGION }}
         image: ${{ env.IMAGE_NAME }}:${{ steps.release.outputs.tag_name }}
-
-    - uses: actions/setup-node@v3
-      if: steps.release.outputs.tag_name != ''
-      with:
-        node-version-file: package.json
-        cache: npm
-        registry-url: https://npm.pkg.github.com
-
-    - name: Build JS package
-      if: steps.release.outputs.tag_name != ''
-      run: |
-        npm --no-git-tag-version version ${{ steps.release.outputs.version }}
-        npm install
-        npm run build
-
-    - name: Publish JS package
-      if: steps.release.outputs.tag_name != ''
-      uses: JS-DevTools/npm-publish@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        registry: https://npm.pkg.github.com
-        access: "public"
-        greater-version-only: true

--- a/consent_api/models.py
+++ b/consent_api/models.py
@@ -89,5 +89,5 @@ class UserConsent(BaseModel):
     def update(self, consent: CookieConsent) -> None:
         """Update a specified user's consent status."""
         self.consent = consent.json
-        db.session.add(self)
+        db.session.merge(self)
         db.session.commit()


### PR DESCRIPTION
* Updating a consent status was giving a 500 error, this fixes that
* Remove deployment pipeline steps for publishing JS client package - client services will need to import the source files directly instead for now