### PR TITLE
Make end-to-end tests explicit about expected consent status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ htmlcov
 client/dist/
 node_modules/
 consent_api.tests.test_end_to_end/
+geckodriver.log

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-coverage:
 
 .PHONY: run
 run:
-	flask --debug run --debugger --reload --port $(PORT)
+	flask --debug run --debugger --reload --host "0.0.0.0" --port $(PORT)
 
 .PHONY: docker-image
 docker-image: clean

--- a/consent_api/tests/test_end_to_end.py
+++ b/consent_api/tests/test_end_to_end.py
@@ -87,10 +87,14 @@ def test_connected_services(browser, govuk, haas, consent_api):
 
     # we can modify the consent status vis the settings form
     cookies_page.reject(["campaigns"])
-    assert cookies_page.get_settings() == CookieConsent(usage=True, settings=True)
+    assert cookies_page.get_settings() == CookieConsent(
+        campaigns=False, usage=True, settings=True
+    )
 
     # the consent status is updated in the API
-    assert consent_api.get_consent(uid) == CookieConsent(usage=True, settings=True)
+    assert consent_api.get_consent(uid) == CookieConsent(
+        campaigns=False, usage=True, settings=True
+    )
 
     # we can go back to the other domain and see consent status is shared
     govuk_cookies_page = govuk.cookies_page.get()


### PR DESCRIPTION
* Tests were implicitly expecting non-set consent categories to be False - this change lists all expected category consent statuses
* Tiny tweaks to gitignore and Makefile