### PR TITLE
Add CLI command to delete expired consent status

### DIFF
--- a/consent_api/__init__.py
+++ b/consent_api/__init__.py
@@ -38,4 +38,5 @@ db.init_app(app)
 migrate = Migrate()
 migrate.init_app(app, db)
 
+import consent_api.commands  # noqa
 import consent_api.views  # noqa

--- a/consent_api/commands/__init__.py
+++ b/consent_api/commands/__init__.py
@@ -1,0 +1,3 @@
+"""Custom CLI commands."""
+
+import consent_api.commands.delete_expired_consent  # noqa

--- a/consent_api/commands/delete_expired_consent.py
+++ b/consent_api/commands/delete_expired_consent.py
@@ -1,0 +1,14 @@
+"""CLI Command to delete expired consent statuses from the database."""
+import click
+from flask.cli import with_appcontext
+
+from consent_api import app
+from consent_api import models
+
+
+@app.cli.command("delete-expired-consent")
+@click.command()
+@with_appcontext
+def delete_expired_consent():
+    """Delete expired consent statuses from the database."""
+    models.UserConsent.bulk_delete(expired=True)


### PR DESCRIPTION
* Add a command which can be called with `flask delete-expired-consent` to delete any consent statuses which were last updated over 7 (configurable) days ago