### PR TITLE
Fix end-to-end tests in Chrome and refactor

### DIFF
--- a/client/src/cookies-page.js
+++ b/client/src/cookies-page.js
@@ -6,12 +6,10 @@
   }
 
   CookieSettings.prototype.init = function () {
-    console.log('CookieSettings.init')
     this.$module.submitSettingsForm = this.submitSettingsForm.bind(this)
     this.$module.getFormValues = this.getFormValues.bind(this)
     this.$module.setFormValues = this.setFormValues.bind(this)
 
-    console.log('CookieSettings.init: add cookies page submit handler')
     document.querySelector('form[data-module=cookie-settings]')
       .addEventListener('submit', this.$module.submitSettingsForm)
 
@@ -24,7 +22,10 @@
 
     this.setFormValues(this.cookiesPolicy)
 
-    Consent.addEventListener('statusShared', this.setFormValues.bind(this))
+    Consent.addEventListener('ConsentStatusLoaded', function (status) {
+      console.log('CookieSettings.handleConsentStatusLoaded:', status)
+      this.setFormValues(status)
+    }.bind(this))
   }
 
   CookieSettings.prototype.setFormValues = function (cookiesPolicy) {
@@ -65,11 +66,10 @@
 
   CookieSettings.prototype.submitSettingsForm = function (event) {
     event.preventDefault()
-    console.log('CookieSettings.submitSettingsForm')
 
     this.cookiesPolicy = this.getFormValues(event.target)
 
-    console.log('CookieSettings.submitSettingsForm: setting cookies_policy', this.cookiesPolicy)
+    console.log('CookieSettings.submitSettingsForm: setting cookiesPolicy', this.cookiesPolicy)
     Utils.setCookie('cookies_policy', JSON.stringify(this.cookiesPolicy), { days: 365 })
     Utils.setCookie('cookies_preferences_set', true, { days: 365 })
 

--- a/consent_api/tests/conftest.py
+++ b/consent_api/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 import sqlalchemy
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.wait import WebDriverWait
 
 from consent_api.tests.api import ConsentAPI
 from consent_api.tests.pom import fake_govuk
@@ -64,6 +65,18 @@ def splinter_driver_kwargs(splinter_webdriver, splinter_driver_kwargs):
             }
         )
     return kwargs
+
+
+def wait_for(self, callback, timeout=10):
+    """Wait until the callback returns True or the timeout is reached."""
+    WebDriverWait(self.driver, timeout).until(callback)
+
+
+@pytest.fixture
+def browser(browser):
+    """Monkeypatch browser instance to add a wait_for convenience method."""
+    browser.wait_for = wait_for.__get__(browser)
+    return browser
 
 
 def get_response_ok(url):

--- a/consent_api/tests/test_views.py
+++ b/consent_api/tests/test_views.py
@@ -57,5 +57,7 @@ def test_set_consent(client, db_session, status):
         url_for("set_consent", uid=uid),
         data={"status": json.dumps(status)},
     )
-    assert response.status_code == 204
+    assert response.status_code == 200
+    assert response.json["uid"] == uid
+    assert response.json["status"] == status
     assert UserConsent.get(uid).consent == status

--- a/consent_api/views.py
+++ b/consent_api/views.py
@@ -24,6 +24,7 @@ def get_consent(uid):
     return jsonify(consent.json)
 
 
+@app.post("/consent", defaults={"uid": None})
 @app.post("/consent/<uid>")
 @cross_origin(origins="*")
 def set_consent(uid):
@@ -36,14 +37,15 @@ def set_consent(uid):
     The body must contain a single name/value pair, with the name `status`, and the
     value must be a JSON object encoded as a string.
     """
-    user = UserConsent(uid=uid)
+    user = UserConsent.get(uid)
     # application/x-www-form-urlencoded body to keep the CORS request simple
     status = request.form["status"]
     # status field contains stringified JSON object
     status = json.loads(status)
     # TODO validation
-    user.update(consent=CookieConsent(**status))
-    return "", 204
+    consent = CookieConsent(**status)
+    user.update(consent=consent)
+    return jsonify(user.json)
 
 
 @app.route("/")


### PR DESCRIPTION
* Chrome was failing because it wasn't waiting for AJAX requests to complete - added explicit waits
* Only request status if have UID from cookie or URL
* Only decorate links if have UID
* Set status with no UID generates a new UID and stores in cookie
* Update set status view to return uid and consent status
* Removed unnecessary cookie deletion at start of tests