### PR TITLE
Make Chrome the default test browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DATABASE_URL ?= postgresql://localhost:5432:$(APP_NAME)
 DOCKER_DB_URL ?= postgresql://host.docker.internal:5432/$(APP_NAME)
 ENV ?= development
 PORT ?= 8000
-SELENIUM_DRIVER ?= firefox
+SELENIUM_DRIVER ?= chrome
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To run end-to-end tests you will need Chrome or Firefox installed. Specify which
 want to use for running tests by setting the `SELENIUM_DRIVER` environment variable, eg:
 
 ```
-export SELENIUM_DRIVER=firefox
+export SELENIUM_DRIVER=chrome
 ```
 
 You also need a running instance of the Consent API and instances of the [SDE Prototype


### PR DESCRIPTION
* End-to-end tests in Github Actions are run on Chrome - better to test against the same browser locally to prevent different results