### PR TITLE
Keep major version tags up-to-date

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Deploy to GCR
     needs: branch-deploy
     environment: ${{ needs.branch-deploy.outputs.environment }}
-    uses: alphagov/consent-api/.github/workflows/build-and-deploy.yaml@8cc1756
+    uses: alphagov/consent-api/.github/workflows/build-and-deploy.yaml@v1
     secrets: inherit
     with:
       image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,6 +36,9 @@ jobs:
         bump_version_scheme: patch
         use_github_release_notes: true
 
+    - name: Keep major version tags up-to-date
+      uses: Actions-R-Us/actions-tagger@latest
+
   deploy-release:
     name: Deploy release
     runs-on: ubuntu-latest


### PR DESCRIPTION
* We want to refer to our reusable workflows with a major version tag (eg v1)
* We don't want to manually update the tag with every release