### PR TITLE
Point to specific commit version of reusable workflow

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -33,7 +33,7 @@ jobs:
   build-and-deploy:
     needs: deploy-request
     environment: ${{ needs.deploy-request.outputs.environment }}
-    uses: alphagov/consent-api/.github/workflows/build-and-deploy.yaml@v1
+    uses: alphagov/consent-api/.github/workflows/build-and-deploy.yaml@80199b3c
     secrets: inherit
     with:
       image-name: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
* The major version tag pointed to a commit where the workflow didn't exist yet
* Although the tag has been updated, let's do a PR to trigger the workflow normally instead of circumventing main branch protection