### PR TITLE
Fix secrets inheritance for reusable workflow

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -34,7 +34,6 @@ jobs:
     needs: deploy-request
     environment: ${{ needs.deploy-request.outputs.environment }}
     uses: alphagov/consent-api/.github/workflows/build-and-deploy.yaml@80199b3c
-    secrets: inherit
     with:
       image-name: ${{ env.IMAGE_NAME }}
       branch-or-tag: ${{ needs.deploy-request.outputs.branch-or-tag }}

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -31,6 +31,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    secrets: inherit
 
     outputs:
       url: ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/main-deploy.yaml
+++ b/.github/workflows/main-deploy.yaml
@@ -51,7 +51,6 @@ jobs:
     if: needs.make-release.outputs.tag_name != ''
 
     uses: alphagov/consent-api/.github/workflows/build-and-deploy.yaml@v1
-    secrets: inherit
     with:
       image-name: ${{ env.IMAGE_NAME }}
       branch-or-tag: ${{ needs.release.outputs.tag_name }}


### PR DESCRIPTION
* It seems the reusable workflow must specify `secrets: inherit` and not the calling workflow. Github Actions documentation is not very clear on this.
* Another PR for a small change to workflows as we can't test them until they are merged