### PR TITLE
Correct typo in main branch deploy workflow

### DIFF
--- a/.github/workflows/main-deploy.yaml
+++ b/.github/workflows/main-deploy.yaml
@@ -30,7 +30,7 @@ jobs:
 
   deploy:
     needs: release
-    if: needs.release.outputs.tag != ""
+    if: needs.release.outputs.tag != ''
     runs-on: ubuntu-latest
 
     environment:


### PR DESCRIPTION
* Need single quotes, not double, because YAML?