### PR TITLE
Fix incorrect default URL in client JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ testing), you can add a `data-consent-api-url` attribute to the `body` tag in
 your HTML file, eg:
 
 ```html
-  <body data-consent-api-url="https://consent-api.example.com/">
+  <body data-consent-api-url="https://consent-api-nw.a.run.app/api/v1/consent/">
 ```
 
 

--- a/client/src/consent.js
+++ b/client/src/consent.js
@@ -7,7 +7,7 @@
   var apiUrl = (function ($el) {
     return $el
       ? $el.dataset.consentApiUrl.replace(/\/?$/, '/')
-      : 'https://consent-api-bgzqvpmbyq-nw.a.run.app/'
+      : 'https://consent-api-bgzqvpmbyq-nw.a.run.app/api/v1/consent/'
   })(document.querySelector('[data-consent-api-url]'))
 
   function Consent() {


### PR DESCRIPTION
* Integrators don't know what the correct URL should be, so the default should at the very least work correctly
* Severity is not too bad, as the URL can be overridden by the data-consent-api-url attribute in the HTML - but the README didn't mention the correct path /api/v1/consent/