### PR TITLE
Fix permissions for GCR access role

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -143,6 +143,7 @@ github_access_to_storage_role = gcp.projects.IAMCustomRole(
         "storage.buckets.get",
         "storage.objects.create",
         "storage.objects.delete",
+        "storage.objects.get",
         "storage.objects.list",
     ],
     role_id="pushToGCR",


### PR DESCRIPTION
* PR branch end-to-end testing needs permission to pull images from GCR, and not just to push