### PR TITLE
Prevent setting cookies_preferences_set cookie on show banner

### DIFF
--- a/client/src/cookie-banner.js
+++ b/client/src/cookie-banner.js
@@ -60,10 +60,6 @@
         noResponse || !acceptedAdditionalCookies
       this.$module.confirmReject.hidden =
         noResponse || acceptedAdditionalCookies
-
-      // XXX this prevents the banner from displaying in future whether or not the user
-      // interacts with it - is this what we want?
-      Utils.setCookie('cookies_preferences_set', 'true', { days: 365 })
     }
   }
 


### PR DESCRIPTION
* It prevents the banner being shown regardless of whether the user interacted with it. This is wrong, it is not what GOV.UK does, and it is confusing for implementors.