### PR TITLE
Fix PR branch deploy workflow

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -42,8 +42,7 @@ jobs:
       image_name: ${{ vars.DOCKER_IMAGE }}
       tag: ${{ needs.request.outputs.ref }}
       environment: ${{ needs.request.outputs.environment }}
-      env_vars:
-        DATABASE_URL=${{ format(secrets.DEV_DB_URL_TEMPLATE, needs.request.outputs.ref) }}
+      database_name: ${{ needs.request.outputs.ref }}
     secrets: inherit
 
   dry-run:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,17 +26,20 @@ on:
         required: false
         type: string
         default: "staging"
-      env_vars:
-        description: "Environment variables to pass to deployment"
+      database_name:
+        description: "Override the deployment database name (for branch deployments)"
         required: false
         type: string
-        default: ""
+        default: "consent-api"
     secrets:
       WIF_PROVIDER:
         description: "Google Cloud Workload Identity Federation provider ID"
         required: true
       WIF_SERVICE_ACCOUNT:
         description: "Google Cloud Workload Identity Federation service account email"
+        required: true
+      DATABASE_URL_TEMPLATE:
+        description: "DATABASE_URL template, allowing overriding the database name"
         required: true
 
     outputs:
@@ -90,10 +93,14 @@ jobs:
             ${{ inputs.image_name }}:latest
             ${{ inputs.image_name }}:${{ inputs.tag }}
 
+      - id: db-url
+        run: |
+          echo "env_vars=${ ${{ inputs.database_name }}:+DATABASE_URL=${{ format(secrets.DATABASE_URL_TEMPLATE, inputs.database_name) }} }" >> $GITHUB_OUTPUT
+
       - uses: google-github-actions/deploy-cloudrun@v0
         id: deploy
         with:
           service: ${{ inputs.service }}
           region: ${{ inputs.region }}
           image: ${{ inputs.image_name }}:${{ inputs.tag }}
-          env_vars: ${{ inputs.env_vars }}
+          env_vars: ${{ steps.db-url.outputs.env_vars }}


### PR DESCRIPTION
* Can't read secrets context in `with` section? Error when overriding DATABASE_URL env var.
* Fixed by passing only the database name, and accessing environment secrets in the reusable workflow.