### PR TITLE
Auto-detect cross-origin links to decorate

### DIFF
--- a/client/src/consent.js
+++ b/client/src/consent.js
@@ -9,6 +9,7 @@
       ? $el.dataset.consentApiUrl.replace(/\/?$/, '/')
       : 'https://consent-api-bgzqvpmbyq-nw.a.run.app/api/v1/consent/'
   })(document.querySelector('[data-consent-api-url]'))
+  var originPattern = /^(https?:)?\/\/([^:/]+)(?::(\d+))?/
 
   function Consent() {
     // one year in milliseconds
@@ -74,11 +75,13 @@
       consent.uid = uid
 
       // add uid URL parameter to consent sharing links
-      var links = document.querySelectorAll('[data-consent-share][href]')
+      var links = document.querySelectorAll('a[href]')
       Array.prototype.forEach.call(links, function (link) {
-        link.addEventListener('click', function (event) {
-          event.target.href = addUrlParameter(event.target.href, uidKey, uid)
-        })
+        if (isCrossOrigin(link.href)) {
+          link.addEventListener('click', function (event) {
+            event.target.href = addUrlParameter(event.target.href, uidKey, uid)
+          })
+        }
       })
 
       // set uid cookie
@@ -156,6 +159,18 @@
         }
       }
     }
+  }
+
+  function isCrossOrigin(url) {
+    var match = url.match(originPattern)
+    if (match) {
+      return (
+        (match[1] && match[1] !== window.location.protocol) ||
+        (match[2] && match[2] !== window.location.hostname) ||
+        (match[3] || '80') !== (window.location.port || '80')
+      )
+    }
+    return false
   }
 
   document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
* Implementers may not have access to HTML to add data-consent-share data attributes to links that should be decorated. This change checks all links on the page and decorates only those that have cross-origin URLs. This introduces the possibility of decorating links unnecessarily - TBD if this is a problem.