### PR TITLE
Downgrade Selenium to 4.9.1

### DIFF
--- a/requirements/production/requirements.txt
+++ b/requirements/production/requirements.txt
@@ -14,3 +14,4 @@ pytest-splinter==3.3.2
 pytest-xdist==3.1.0
 python-dotenv==0.21.0
 requests==2.28.2
+selenium==4.9.1


### PR DESCRIPTION
* Breaking change to API means end-to-end tests fail to run