### PR TITLE
Escape database URL in alembic migrations environment

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,15 +1,13 @@
 import asyncio
 from logging.config import fileConfig
 
+from alembic import context
+from consent_api import models  # noqa
+from consent_api.config import SQLALCHEMY_DATABASE_URI
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 from sqlmodel import SQLModel
-
-from alembic import context
-
-from consent_api import models  # noqa
-from consent_api.config import SQLALCHEMY_DATABASE_URI
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -20,7 +18,10 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-config.set_main_option('sqlalchemy.url', SQLALCHEMY_DATABASE_URI)
+# set_main_option value is passed to ConfigParser.set, which supports variable
+# interpolation using pyformat (eg: '%(some_value)s'). Raw percent signs must be
+# escaped (eg: '%%')
+config.set_main_option("sqlalchemy.url", SQLALCHEMY_DATABASE_URI.replace("%", "%%"))
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
* It tries to interpolate variables using pyformat (eg `%(some_var)s`), so raw percent signs must be escaped (eg `%%`)
* The database password (randomly generated) contains a raw percent sign, so migrations failed to run