### PR TITLE
Configure Uvicorn to pass proxy headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,5 @@ ENV DATABASE_URL="postgresql+asyncpg://postgres@host.docker.internal:5432/$APP_N
 ENV PATH="/home/app/venv/bin:$PATH"
 ENV PYTHONUNBUFFERED="True"
 
-CMD alembic --config migrations/alembic.ini upgrade head && uvicorn ${APP_NAME}:app --host="0.0.0.0" --port ${PORT:-8000}
+CMD alembic --config migrations/alembic.ini upgrade head && uvicorn ${APP_NAME}:app --host="0.0.0.0" --port ${PORT:-8000} --proxy-headers
 HEALTHCHECK CMD python -c "import urllib.request as r; r.urlopen('http://localhost:${PORT:-8000}/health')"


### PR DESCRIPTION
* Starlette/FastAPI static asset URLs include the scheme (http/https) and use the X-Forwarded-Proto HTTP header to generate them. The default is 'http'.
* Uvicorn doesn't pass on the X-Forwarded-Proto header by default
* When running in Google Cloud Run, HTTPS/TLS is handled before requests are forwarded to Uvicorn
* The browser requests a page with https and the static asset URLs within are http, so browsers block them

No release, because static assets are not necessary for the functionality of the Single Consent service. They are just used by the self-service mockup website.