### PR TITLE
Allow proxy headers from any IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,5 @@ ENV DATABASE_URL="postgresql+asyncpg://postgres@host.docker.internal:5432/$APP_N
 ENV PATH="/home/app/venv/bin:$PATH"
 ENV PYTHONUNBUFFERED="True"
 
-CMD alembic --config migrations/alembic.ini upgrade head && uvicorn ${APP_NAME}:app --host="0.0.0.0" --port ${PORT:-8000} --proxy-headers
+CMD alembic --config migrations/alembic.ini upgrade head && uvicorn ${APP_NAME}:app --host="0.0.0.0" --port ${PORT:-8000} --proxy-headers --forwarded-allow-ips="*"
 HEALTHCHECK CMD python -c "import urllib.request as r; r.urlopen('http://localhost:${PORT:-8000}/health')"


### PR DESCRIPTION
* Uvicorn is running in a container on a Docker network, so requests may be coming from dynamic IP address
* Uvicorn is only accessible within Google Cloud Run, so this is safe