### PR TITLE
Remove the endpoint that fetches all consent statuses

### DIFF
--- a/consent_api/routers/consent.py
+++ b/consent_api/routers/consent.py
@@ -66,16 +66,6 @@ async def get_user_consent(
         return await db.scalars(query)
 
 
-@consent.get("/")
-async def get_all_consent_statuses(
-    db: AsyncSession = fastapi.Depends(db_session),
-    origin: Annotated[str | None, Header()] = None,
-) -> list[UserConsent]:
-    """Get all consent statuses."""
-    await register_origin(origin, db)
-    return list(await get_user_consent(None, db))
-
-
 Consent = Annotated[CookieConsent, fastapi.Depends(CookieConsent.as_form)]
 
 


### PR DESCRIPTION
* It is not necessary
* It returns a lot of data and could inadvertently DoS the API