### PR TITLE
Use Pulumi access token

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,6 +62,8 @@ jobs:
       - uses: pulumi/actions@v4
 
       - id: stack
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
           outputs=$(pulumi stack output -j -s ${{ inputs.environment }})
           echo WIF_SERVICE_ACCOUNT=$(echo $outputs | jq -r '.service_account') >> "$GITHUB_OUTPUT"

--- a/.github/workflows/open-pull-request.yaml
+++ b/.github/workflows/open-pull-request.yaml
@@ -19,12 +19,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: pulumi/actions@v4
+
+      - id: stack
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          outputs=$(pulumi stack output -j -s "development")
+          echo WIF_SERVICE_ACCOUNT=$(echo $outputs | jq -r '.service_account') >> "$GITHUB_OUTPUT"
+          echo WIF_PROVIDER=$(echo $outputs | jq -r '.workload_identity_provider') >> "$GITHUB_OUTPUT"
+
       - uses: google-github-actions/auth@v1
         id: auth
         with:
           token_format: access_token
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ steps.stack.outputs.WIF_PROVIDER }}
+          service_account: ${{ steps.stack.outputs.WIF_SERVICE_ACCOUNT }}
 
       - uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
* We can fetch the Workload Identity Provider and Service Account name from the Pulumi stack outputs for the environment, no need for Github secrets. This is more secure and more flexible.
* Forgot to add the Pulumi access token to the environment
* Get the Provider and service account dynamically for the development image too