### PR TITLE
Prevent passing both branch and tag to deploy script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -105,5 +105,5 @@ jobs:
         env:
           ENV: ${{ inputs.environment }}
           BRANCH: ${{ inputs.is_branch && format('--branch {0}', inputs.tag) || '' }}
-          TAG: ${{ format('--tag {0}', inputs.tag) }}
+          TAG: ${{ inputs.is_branch && '' || format('--tag {0}', inputs.tag) }}
           PREVIEW: ${{ inputs.noop && '--preview' || '' }}


### PR DESCRIPTION
* It only wants one and fails if deploying a branch currently