### PR TITLE
Invert logic for checking if tag passed to deploy script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -105,5 +105,5 @@ jobs:
         env:
           ENV: ${{ inputs.environment }}
           BRANCH: ${{ inputs.is_branch && format('--branch {0}', inputs.tag) || '' }}
-          TAG: ${{ inputs.is_branch && '' || format('--tag {0}', inputs.tag) }}
+          TAG: ${{ !inputs.is_branch && format('--tag {0}', inputs.tag) || '' }}
           PREVIEW: ${{ inputs.noop && '--preview' || '' }}


### PR DESCRIPTION
* It didn't work with `test && '' || 'something'`, because of operator precedence. `test && ''` is false, so the rest of the expression was not evaluated.