### PR TITLE
Remove WIF_PROVIDER and WIF_SERVICE_ACCOUNT secrets

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,11 +26,8 @@ on:
         required: false
         type: boolean
     secrets:
-      WIF_PROVIDER:
-        description: "Google Cloud Workload Identity Federation provider ID"
-        required: true
-      WIF_SERVICE_ACCOUNT:
-        description: "Google Cloud Workload Identity Federation service account email"
+      PULUMI_ACCESS_TOKEN:
+        description: "Pulumi Access Token"
         required: true
 
     outputs:


### PR DESCRIPTION
* We fetch these values from the Pulumi stack for the specified environment
* Add the PULUMI_ACCESS_TOKEN secret, needed to fetch these values and to run the deployment script