### PR TITLE
Add a callback hook to setStatus

### DIFF
--- a/client/src/singleconsent.js
+++ b/client/src/singleconsent.js
@@ -40,7 +40,7 @@
     this.eventListeners.push(callback)
   }
 
-  Consent.prototype.setStatus = function (status) {
+  Consent.prototype.setStatus = function (status, callback) {
     if (status) {
       request(
         apiUrl.concat(this.uid || ''),
@@ -52,6 +52,9 @@
         function (response) {
           // get the current uid from the API if we don't already have one
           setUid(this, response.uid)
+          if (callback) {
+            callback()
+          }
         }.bind(this)
       )
     }


### PR DESCRIPTION
* Caller may want to do something after the status has been set. Eg: DfE want to reload the page after the cookie banner is clicked, but this cancels the setStatus AJAX request. Instead, they could reload the page in a callback once the request is complete.