### PR TITLE
Instantiate the Consent object earlier in a page load

### DIFF
--- a/client/src/singleconsent.js
+++ b/client/src/singleconsent.js
@@ -187,8 +187,9 @@
     return origin
   }
 
+  window.Consent = new Consent()
+
   document.addEventListener('DOMContentLoaded', function () {
-    window.Consent = new Consent()
     window.Consent.init()
   })
 })()


### PR DESCRIPTION
* Allows more time for other Javascripts to register callbacks