### PR TITLE
Rename Consent object to GovSingleConsent

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -58,7 +58,7 @@ user has shared consent, you need to register a callback function with the
 following example Javascript code:
 
 ```javascript
-SingleConsent.onStatusLoaded(function (consentData) {
+GovSingleConsent.onStatusLoaded(function (consentData) {
   document.querySelector("#example-cookie-banner-id").hidden = true
 })
 ```
@@ -77,7 +77,7 @@ exampleCookieConsentStatusObject = {
   "campaigns": false,
 }
 
-Consent.setStatus(exampleCookieConsentStatusObject)
+GovSingleConsent.setStatus(exampleCookieConsentStatusObject)
 ```
 
 The structure of the consent data object is currently based on the
@@ -133,7 +133,7 @@ with the consent status object as an argument.</td></tr>
 ##### Example
 
 ```javascript
-Consent.onStatusLoaded((status) => {
+GovSingleConsent.onStatusLoaded((status) => {
   console.log("Consent Status:")
   console.log(`- Essential cookies (${status.essential})`)
   console.log(`- Campaign cookies (${status.campaigns})`)
@@ -170,7 +170,7 @@ with the consent status as an argument.</td></tr>
 ##### Example
 
 ```javascript
-Consent.setStatus(
+GovSingleConsent.setStatus(
   acceptAllCookies,
   (status) => {
     console.log("Consent status successfully updated to", status)

--- a/client/src/singleconsent.js
+++ b/client/src/singleconsent.js
@@ -1,16 +1,16 @@
 ;(function () {
   'use strict'
 
-  var uidKey = 'consent_uid'
+  var uidKey = 'gov_singleconsent_uid'
   var uidFromCookie = findByKey(uidKey, document.cookie.split(';'))
   var uidFromUrl = findByKey(uidKey, parseUrl(location.href).params)
   var apiUrl = (function ($el) {
     return $el
       ? $el.dataset.consentApiUrl.replace(/\/?$/, '/')
       : 'https://consent-api-bgzqvpmbyq-nw.a.run.app/api/v1/consent/'
-  })(document.querySelector('[data-consent-api-url]'))
+  })(document.querySelector('[data-gov-singleconsent-api-url]'))
 
-  function Consent() {
+  function GovSingleConsent() {
     // one year in milliseconds
     this.COOKIE_LIFETIME = 365 * 24 * 60 * 60 * 1000
     this.ACCEPT_ALL = {
@@ -29,7 +29,7 @@
     this.eventListeners = []
   }
 
-  Consent.prototype.init = function () {
+  GovSingleConsent.prototype.init = function () {
     // hide uid URL parameter
     history.replaceState(null, null, removeUrlParameter(location.href, uidKey))
 
@@ -49,11 +49,11 @@
     }
   }
 
-  Consent.prototype.onStatusLoaded = function (callback) {
+  GovSingleConsent.prototype.onStatusLoaded = function (callback) {
     this.eventListeners.push(callback)
   }
 
-  Consent.prototype.setStatus = function (status, callback) {
+  GovSingleConsent.prototype.setStatus = function (status, callback) {
     if (status) {
       request(
         apiUrl.concat(this.uid || ''),
@@ -66,7 +66,7 @@
           // get the current uid from the API if we don't already have one
           setUid(this, response.uid)
           if (callback) {
-            callback()
+            callback(status)
           }
         }.bind(this)
       )
@@ -99,7 +99,7 @@
         .concat('=', uid)
         .concat(
           '; path=/',
-          '; max-age='.concat(Consent.COOKIE_LIFETIME),
+          '; max-age='.concat(GovSingleConsent.COOKIE_LIFETIME),
           document.location.protocol === 'https:' ? '; Secure' : ''
         )
     }
@@ -187,9 +187,9 @@
     return origin
   }
 
-  window.Consent = new Consent()
+  window.GovSingleConsent = new GovSingleConsent()
 
   document.addEventListener('DOMContentLoaded', function () {
-    window.Consent.init()
+    window.GovSingleConsent.init()
   })
 })()

--- a/consent_api/tests/test_end_to_end.py
+++ b/consent_api/tests/test_end_to_end.py
@@ -32,8 +32,8 @@ def test_single_service(browser, dummy_service, consent_api):
     assert CookieConsent(**json.loads(policy)) == CookieConsent.REJECT_ALL
 
     # we have been assigned a UID
-    browser.wait_for(lambda _: "consent_uid" in browser.cookies.all())
-    uid = browser.cookies.all()["consent_uid"]
+    browser.wait_for(lambda _: "gov_singleconsent_uid" in browser.cookies.all())
+    uid = browser.cookies.all()["gov_singleconsent_uid"]
 
     # consent status is also recorded in the API associated with the current UID
     assert consent_api.get_consent(uid) == CookieConsent.REJECT_ALL
@@ -83,8 +83,8 @@ def test_connected_services(browser, dummy_service, consent_api):
     policy = browser.cookies.all()["cookies_policy"]
     assert CookieConsent(**json.loads(policy)) == CookieConsent.ACCEPT_ALL
 
-    browser.wait_for(lambda _: "consent_uid" in browser.cookies.all())
-    uid = browser.cookies.all()["consent_uid"]
+    browser.wait_for(lambda _: "gov_singleconsent_uid" in browser.cookies.all())
+    uid = browser.cookies.all()["gov_singleconsent_uid"]
     assert consent_api.get_consent(uid) == CookieConsent.ACCEPT_ALL
 
     # browse to a different domain/origin
@@ -95,7 +95,7 @@ def test_connected_services(browser, dummy_service, consent_api):
     assert not homepage.cookie_banner.visible
 
     # assert the UID has been carried over
-    assert browser.cookies.all()["consent_uid"] == uid
+    assert browser.cookies.all()["gov_singleconsent_uid"] == uid
     policy = browser.cookies.all()["cookies_policy"]
     assert CookieConsent(**json.loads(policy)) == CookieConsent.ACCEPT_ALL
 


### PR DESCRIPTION
* Avoid collisions with 3rd party Javascripts
* Also rename URL parameter and cookie