### PR TITLE
Prioritise a UID in the URL over one in a cookie

### DIFF
--- a/client/src/GovSingleConsent.ts
+++ b/client/src/GovSingleConsent.ts
@@ -52,7 +52,7 @@ export class GovSingleConsent {
     this.config = new GovConsentConfig()
 
     // get the current uid from the cookie or the URL if it exists
-    this.updateUID(this.config.uidFromCookie || this.config.uidFromUrl)
+    this.updateUID(this.config.uidFromUrl || this.config.uidFromCookie)
     if (this.uid) {
       var getConsentsUrl = this.config.getApiUrl().concat(this.uid)
 


### PR DESCRIPTION
This handles the following case.

1. User visits site A, sets their preferences and acquires a UID, which is recorded in a cookie.
2. User visits site B, sets new preferences and acquires a new UID
3. User navigates from site B to site A, where the UID in the URL parameter ought to override the one in the cookie, because it is newer.

We are aware that this doesn't handle the following case:

3. [alternative] User navigates from site A to site B, where the UID in the URL parameter ought *not* to override the one in the cookie, because it is older.