### PR TITLE
Remove endpoint to get all consents

### DIFF
--- a/consent_api/routers/consent.py
+++ b/consent_api/routers/consent.py
@@ -48,14 +48,6 @@ async def get_user_consent(
         return await db.scalars(query)
 
 
-@consent.get("/")
-async def get_all_consent_statuses(
-    db: AsyncSession = fastapi.Depends(db_session),
-) -> list[UserConsent]:
-    """Get all consent statuses."""
-    return list(await get_user_consent(None, db))
-
-
 Consent = Annotated[CookieConsent, fastapi.Depends(CookieConsent.as_form)]
 
 


### PR DESCRIPTION
* Not needed for public use
* Query is too big and exceeds memory allowance
* Data protection